### PR TITLE
Use custom task-buildah-oci-ta bundle with increased memory limits

### DIFF
--- a/.tekton/pulp-develop-pull-request.yaml
+++ b/.tekton/pulp-develop-pull-request.yaml
@@ -234,7 +234,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:681d9f65a7f50cb260ee576ccab551e11d63c549f1e1ef3d201da3c112855bd6
+          value: quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/pulp-develop-push.yaml
+++ b/.tekton/pulp-develop-push.yaml
@@ -231,7 +231,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9@sha256:681d9f65a7f50cb260ee576ccab551e11d63c549f1e1ef3d201da3c112855bd6
+          value: quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- Switches `pulp-develop` push and pull-request pipelines from the upstream `quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.9` to the project-owned `quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63`
- The custom bundle increases memory/CPU limits to prevent OOM failures when building large images (see theforeman/theforeman-rel-eng-konflux#20)
- Part of the policy: all OCI image repos must reference the project-owned bundle (tracked in theforeman/theforeman-rel-eng-konflux#40)

## Test plan
- [ ] Verify Konflux pipeline runs successfully with the new bundle reference
- [ ] Confirm no OOM failures in `build` and `sbom-syft-generate` steps

Closes theforeman/theforeman-rel-eng-konflux#40