### PR TITLE
images/pulp: add OCI image labels

### DIFF
--- a/.tekton/pulp-3-19-pull-request.yaml
+++ b/.tekton/pulp-3-19-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       == "foreman-3.19" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-3-19-pull-request.yaml".pathChanged()
       || "images/pulp/Containerfile".pathChanged() )
   labels:
-    appstudio.openshift.io/application: pulp
+    appstudio.openshift.io/application: pulp-3-19
     appstudio.openshift.io/component: pulp-3-19
     pipelines.appstudio.openshift.io/type: build
   name: pulp-3-19-on-pull-request

--- a/.tekton/pulp-3-19-push.yaml
+++ b/.tekton/pulp-3-19-push.yaml
@@ -11,7 +11,7 @@ metadata:
       == "foreman-3.19" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-3-19-push.yaml".pathChanged()
       || "images/pulp/Containerfile".pathChanged() )
   labels:
-    appstudio.openshift.io/application: pulp
+    appstudio.openshift.io/application: pulp-3-19
     appstudio.openshift.io/component: pulp-3-19
     pipelines.appstudio.openshift.io/type: build
   name: pulp-3-19-on-push

--- a/images/pulp/Containerfile
+++ b/images/pulp/Containerfile
@@ -19,3 +19,8 @@ RUN dnf -y update && \
 COPY --chmod=0755 assets/pulp-api /usr/bin/pulp-api
 COPY --chmod=0755 assets/pulp-content /usr/bin/pulp-content
 COPY --chmod=0755 assets/pulp-worker /usr/bin/pulp-worker
+
+LABEL url="https://theforeman.org/" \
+      name="foreman/pulp" \
+      description="Pulp content management platform for the Foreman project" \
+      summary="Pulp content management platform"


### PR DESCRIPTION
Add standard OCI image labels to the Containerfile for the foreman-3.19 branch.

Triggers the Konflux pull-request pipeline to validate the `pulp-3-19` component build.