### PR TITLE
fix: use stage namespace for pulp develop output-image

### DIFF
--- a/.tekton/pulp-develop-pull-request.yaml
+++ b/.tekton/pulp-develop-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/pulp-stage:on-pr-{{revision}}
+    value: quay.io/foreman/stage/pulp:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/pulp-develop-push.yaml
+++ b/.tekton/pulp-develop-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/pulp-stage:{{revision}}
+    value: quay.io/foreman/stage/pulp:{{revision}}
   - name: dockerfile
     value: images/pulp/Containerfile
   - name: path-context


### PR DESCRIPTION
## Summary

Update `output-image` in Tekton push pipelines to use the new stage namespace convention.

**Before:** `quay.io/foreman/$service-stage:{{revision}}`
**After:** `quay.io/foreman/stage/$service:{{revision}}`

This aligns with theforeman/foremanctl#522, which changes stage image names to use a namespace instead of a name suffix, enabling registry override mirroring between stage and production.