### PR TITLE
chore(deps): update quay.io/centos/centos:stream9 docker digest to b5986e7

### DIFF
--- a/images/pulp/Containerfile.digest
+++ b/images/pulp/Containerfile.digest
@@ -1,1 +1,1 @@
-BASE_IMAGE=quay.io/centos/centos:stream9@sha256:2ec5fc9b994c9f370b10e7bf07d3c1a7740e934d3c8f3d78c105b5e635d3cffb
+BASE_IMAGE=quay.io/centos/centos:stream9@sha256:b5986e7a0621e45530759a5680deb01190f9c990892b9dd05e6786e9c4107b56


### PR DESCRIPTION
Update quay.io/centos/centos:stream9 docker image digest.

Opened manually as mintmaker committed the update but did not open the PR automatically.