### PR TITLE
chore(renovate): override tekton schedule to run at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,10 @@
     {
       "matchDatasources": ["docker"],
       "schedule": ["at any time"]
+    },
+    {
+      "matchManagers": ["tekton"],
+      "schedule": ["at any time"]
     }
   ]
 }


### PR DESCRIPTION
Mintmaker's global config gates Konflux tekton reference updates to Saturdays only (`* 5-23 * * 6`). Override the schedule at the repo level so PRs are created as soon as new task bundle digests are available.