### PR TITLE
Fix CEL target_branch: main → master

### DIFF
--- a/.tekton/pulp-develop-pull-request.yaml
+++ b/.tekton/pulp-develop-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-develop-pull-request.yaml".pathChanged()
+      == "master" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-develop-pull-request.yaml".pathChanged()
       || "images/pulp/Containerfile".pathChanged() )
   creationTimestamp: null
   labels:

--- a/.tekton/pulp-develop-push.yaml
+++ b/.tekton/pulp-develop-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-develop-push.yaml".pathChanged()
+      == "master" && ( "images/pulp/***".pathChanged() || ".tekton/pulp-develop-push.yaml".pathChanged()
       || "images/pulp/Containerfile".pathChanged() )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary

The default branch of this repository was renamed from `main` to `master`. The `.tekton` PipelinesAsCode CEL expressions still reference `"main"`, which means the nightly builds no longer trigger on pushes to `master`.

- `.tekton/pulp-develop-push.yaml`: `target_branch == "main"` → `"master"`
- `.tekton/pulp-develop-pull-request.yaml`: `target_branch == "main"` → `"master"`

Fixes https://github.com/theforeman/pulp-oci-images/issues/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)